### PR TITLE
Setup for gradual WebRTC connection using ws-webrtc-relay

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,15 @@
 </head>
 
 <body>
+    <div class="communicator-toggler">broadcast</div>
+    <div class="communicator">
+        <form id="peer-list"></form>
+        <div class="buttons">
+            <button type="button" id="scan-btn">Scan</button>
+            <button type="button" id="connect-btn" disabled>Connect</button>
+        </div>
+    </div>
+
     <div id="maingif">
         <img src="https://dialcava.com/media/images/gif/maingif1.gif" width="70">
     </div>
@@ -84,6 +93,72 @@
             font-size: 20px;
             text-align: right;
             font-family: 'Libre Caslon Display', serif;
+        }
+
+        .communicator-toggler {
+            text-decoration: underline;
+            cursor: pointer;
+            position: absolute;
+            top: 1%;
+            right: 1%;
+            color: #fff;
+        }
+
+        .communicator {
+            display: none;
+            flex-direction: column;
+            justify-content: space-between;
+            width: fit-content;
+            height: fit-content;
+            position: absolute;
+            top: 5%;
+            right: 1%;
+            background: #fff;
+            padding: 0.8em;
+            border-radius: 5px;
+            box-sizing: border-box;
+        }
+
+        .communicator #peer-list {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-around;
+            margin-bottom: 5px;
+        }
+
+        .communicator #peer-list .input-group {
+            margin-top: 5px;
+            margin-bottom: 5px;
+        }
+
+        .communicator .buttons {
+            display: flex;
+            flex-direction: row;
+            justify-content: space-between;
+        }
+
+        .communicator input[type=radio] {
+            display: none;
+            visibility: hidden;
+        }
+
+        .communicator label {
+            border: 2px solid transparent;
+            border-radius: 5px;
+            cursor: pointer;
+        }
+
+        .communicator label:hover {
+            border: 2px solid rgb(177, 177, 253);
+        }
+
+        .communicator input[type=radio] ~ label {
+            background: #fff;
+            padding: 3px;
+        }
+
+        .communicator input[type=radio]:checked ~ label {
+            background: rgb(177, 177, 253);
         }
     </style>
 </body>

--- a/js/communicator/Communicator.js
+++ b/js/communicator/Communicator.js
@@ -1,0 +1,155 @@
+import { signalServer } from '../constants';
+
+class Communicator {
+  constructor(stream) {
+    this.stream = stream;
+    this.activePeers = [];
+
+    this.peerConnection = window.peerConnection = new RTCPeerConnection(null);
+    this.webSocket      = new WebSocket(signalServer);
+    this.webSocket.onmessage = this.onMessage.bind(this);
+    this.webSocket.onopen = this.scan.bind(this);
+
+    this.peerConnection.onnegotiationneeded = this.onNegotiation.bind(this);
+    this.peerConnection.onicecandidate = this.onCandidate.bind(this);
+
+    setTimeout(() => {
+      console.log("Building display");
+      this.scanBtn = document.querySelector('#scan-btn');
+      this.connectBtn = document.querySelector('#connect-btn');
+      this.buildDisplay();
+    }, 1000);
+  }
+
+  start() {
+    // Adding a track to the peerConnection should trigger
+    // the onNegotiation event, which will send an offer
+    // to the signaling server.
+    const track = this.stream.getAudioTracks()[0];
+    this.peerConnection.addTrack(track, this.stream);
+    this.connectBtn.disabled = true;
+  }
+
+  scan() {
+    console.log("Scanning for clients!");
+    this.webSocket.send(JSON.stringify({ type: 'scan' }));
+  }
+
+  buildDisplay() {
+    this.scanBtn.addEventListener('click', () => (this.scan()));
+    this.connectBtn.addEventListener('click', () => (this.start()));
+
+    const toggler = document.querySelector('.communicator-toggler');
+    const communicator = document.querySelector('.communicator');
+    toggler.addEventListener('click', () => {
+      console.log(communicator.style.display);
+      communicator.style.display = communicator.style.display == 'none' ? 'flex' : 'none';
+    })
+  }
+
+  buildPeerList() {
+    console.log(this);
+    const peerListForm = document.querySelector('#peer-list');
+    const list = this.activePeers.flatMap(({ id }) => {
+      let div = document.createElement('div');
+      div.className = 'input-group';
+      let input = document.createElement('input');
+      input.type = 'radio';
+      input.value = id;
+      input.id = id;
+      input.name = 'peers';
+      let label = document.createElement('label');
+      label.textContent = id;
+      label.setAttribute('for', id);
+
+      div.append(input, label);
+      return div;
+    });
+
+    peerListForm.addEventListener("change", (e) => {
+      this.targetPeer = e.target.value;
+      this.connectBtn.disabled = false;
+    });
+
+    while(peerListForm.firstChild) {
+      peerListForm.removeChild(peerListForm.firstChild);
+    }
+
+    list.forEach(li => peerListForm.append(li));
+  }
+
+  onMessage(event) {
+    console.log("Receiving local socket message", event);
+    const pc  = this.peerConnection;
+    const message = JSON.parse(event.data);
+
+    const { type, sender, data } = message;
+
+    switch (type) {
+      case 'scan':
+        console.log("Received active clients!", data);
+        const { login, peers } = data;
+        this.login = login;
+        this.activePeers = peers.filter(p => p.id !== this.login);
+        this.buildPeerList();
+        break;
+      case 'sdp':
+        this.receiveAnswer(data, sender);
+        break;
+      case 'candidate':
+        pc.addIceCandidate(new RTCIceCandidate(data))
+          .catch(error => console.log(error));
+        break;
+      default:
+        break;
+    }
+  }
+
+  onNegotiation(e) {
+    console.log("Negotiation needed", e);
+    this.sendOffer();
+  }
+
+  onCandidate(e) {
+    console.log("Received ICE Candidate", e);
+    const data = e.candidate;
+
+    this.webSocket.send(
+      JSON.stringify({ type: 'candidate', target: this.targetPeer, data })
+    );
+  }
+
+  sendOffer() {
+    const pc = this.peerConnection;
+    const ws = this.webSocket;
+    pc.createOffer()
+      .then(offer => pc.setLocalDescription(offer))
+      .then(() => ws.send(JSON.stringify({
+        type: 'sdp',
+        target: this.targetPeer,
+        data: pc.localDescription
+      })))
+      .catch(error => console.log("Error sending offer", error));
+  }
+
+  receiveAnswer(data) {
+    const pc = this.peerConnection;
+    const ws = this.webSocket;
+
+    pc.setRemoteDescription(new RTCSessionDescription(data))
+      .then(() => {
+        if (pc.signalingState == "stable") return;
+        
+        return pc.createAnswer()
+          .then(answer => pc.setLocalDescription(answer))
+          .then(() => ws.send(JSON.stringify({
+            type: 'sdp',
+            target: this.targetPeer,
+            data: pc.localDescription
+          })));
+      })
+      .catch(error => console.log("Error receiving answer", error));
+  }
+}
+
+export default Communicator;

--- a/js/constants.js
+++ b/js/constants.js
@@ -1,6 +1,9 @@
 export const winWidth = window.innerWidth;
 export const winHeight = window.innerHeight;
 
+const signalPort = 443;
+export const signalServer = `ws://${window.location.host.split(':')[0]}:${signalPort}/`;
+
 export const NUMBER_OF_ROWS = 4;
 
 export const BPM = 300;

--- a/script.js
+++ b/script.js
@@ -21,6 +21,9 @@ import earth from "./samples/earth/*.wav"
 import milpad from "./samples/milpad/*.wav"
 import alienpad from "./samples/alienpad/*.wav"
 
+import Communicator from './js/communicator/Communicator'
+const streamDestination = Tone.context.createMediaStreamDestination();
+
 var dataWeather;
 var layer;
 var dummyLayerProps;
@@ -237,6 +240,7 @@ class Layer {
         this.reverb.connect(this.gain);
         this.reverb.generate();
         this.gain.toMaster();
+        Tone.connect(this.gain, streamDestination);
     }
     plugLeds() {
         let posY = (this.layerNumber * 80) + 180;
@@ -424,3 +428,5 @@ function assignNote(currLayer, currStep, minOct, maxOct) {
         currLayer.velMod[currStep] = auxf.getRandomNum(1, 2, 0);
     }
 }
+
+const comm = new Communicator(streamDestination.stream);


### PR DESCRIPTION
Broadcaster setup for webRTC. Allows for unidirectional media stream broadcast between peers signalled by the relay server.

This implemention uses [ws-webrtc-relay](https://github.com/jmrfrosa/ws-webrtc-relay) as a standalone relay node and [foresee](https://github.com/jmrfrosa/foresee) as a pilot client.